### PR TITLE
Use heroes-talents icons

### DIFF
--- a/app/Ability.php
+++ b/app/Ability.php
@@ -52,6 +52,6 @@ class Ability extends Model
 
     public function getIconUrlAttribute()
     {
-        return $this->icon ? ["64x64" => "https://github.com/heroespatchnotes/heroes-talents/raw/master/images/talents/{$this->icon}"] : [];
+        return $this->icon ? ["64x64" => "https://raw.githubusercontent.com/heroespatchnotes/heroes-talents/master/images/talents/{$this->icon}"] : [];
     }
 }

--- a/app/Ability.php
+++ b/app/Ability.php
@@ -49,4 +49,9 @@ class Ability extends Model
     {
         return $this->belongsTo(Hero::class);
     }
+
+    public function getIconUrlAttribute()
+    {
+        return $this->icon ? ["64x64" => "https://github.com/heroespatchnotes/heroes-talents/raw/master/images/talents/{$this->icon}"] : [];
+    }
 }

--- a/app/Hero.php
+++ b/app/Hero.php
@@ -57,6 +57,6 @@ class Hero extends Model
 
     public function getIconUrlAttribute()
     {
-        return ["92x93" => "http://s3.hotsapi.net/img/heroes/92x93/$this->short_name.png"];
+        return ["92x93" => "https://github.com/heroespatchnotes/heroes-talents/raw/master/images/heroes/{$this->short_name}.png"];
     }
 }

--- a/app/Hero.php
+++ b/app/Hero.php
@@ -57,6 +57,6 @@ class Hero extends Model
 
     public function getIconUrlAttribute()
     {
-        return ["92x93" => "https://github.com/heroespatchnotes/heroes-talents/raw/master/images/heroes/{$this->short_name}.png"];
+        return ["92x93" => "https://raw.githubusercontent.com/heroespatchnotes/heroes-talents/master/images/heroes/{$this->short_name}.png"];
     }
 }

--- a/app/Talent.php
+++ b/app/Talent.php
@@ -47,6 +47,6 @@ class Talent extends Model
 
     public function getIconUrlAttribute()
     {
-        return $this->icon ? ["64x64" => "http://s3.hotsapi.net/img/talents/64x64/$this->icon"] : [];
+        return $this->icon ? ["64x64" => "https://github.com/heroespatchnotes/heroes-talents/raw/master/images/talents/{$this->icon}"] : [];
     }
 }

--- a/app/Talent.php
+++ b/app/Talent.php
@@ -47,6 +47,6 @@ class Talent extends Model
 
     public function getIconUrlAttribute()
     {
-        return $this->icon ? ["64x64" => "https://github.com/heroespatchnotes/heroes-talents/raw/master/images/talents/{$this->icon}"] : [];
+        return $this->icon ? ["64x64" => "https://raw.githubusercontent.com/heroespatchnotes/heroes-talents/master/images/talents/{$this->icon}"] : [];
     }
 }


### PR DESCRIPTION
Replaces URL references to hero, ability, and talent icons to their equivalent at `heroes-talents`