### PR TITLE
add default value on deleted column

### DIFF
--- a/database/migrations/2019_12_26_134611_add_default_value_for_deleted.php
+++ b/database/migrations/2019_12_26_134611_add_default_value_for_deleted.php
@@ -13,8 +13,11 @@ class AddDefaultValueForDeleted extends Migration
      */
     public function up()
     {
-
-        DB::statement('ALTER TABLE `hotsapi`.`replays` CHANGE COLUMN `deleted` `deleted` TINYINT(1) NOT NULL DEFAULT \'0\'');
+        // https://stackoverflow.com/a/42107554/9539
+        DB::getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
+        Schema::table('replays', function (Blueprint $table) {
+            $table->integer('deleted')->default(0)->change();
+        });
     }
 
     /**
@@ -24,6 +27,10 @@ class AddDefaultValueForDeleted extends Migration
      */
     public function down()
     {
-        DB::statement('ALTER TABLE `hotsapi`.`replays` CHANGE COLUMN `deleted` `deleted` TINYINT(1) NOT NULL');
+        // https://stackoverflow.com/a/42107554/9539
+        DB::getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
+        Schema::table('replays', function (Blueprint $table) {
+            $table->integer('deleted')->default(NULL)->change();
+        });
     }
 }

--- a/database/migrations/2019_12_26_134611_add_default_value_for_deleted.php
+++ b/database/migrations/2019_12_26_134611_add_default_value_for_deleted.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddDefaultValueForDeleted extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+
+        DB::statement('ALTER TABLE `hotsapi`.`replays` CHANGE COLUMN `deleted` `deleted` TINYINT(1) NOT NULL DEFAULT \'0\'');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::statement('ALTER TABLE `hotsapi`.`replays` CHANGE COLUMN `deleted` `deleted` TINYINT(1) NOT NULL');
+    }
+}


### PR DESCRIPTION
On a new database instance, uploading a replay fails with:

```
SQLSTATE[HY000]: General error: 1364 Field 'deleted' doesn't have a default value 
(SQL: insert into `replays` (`fingerprint`, `game_type`, `game_date`, `game_length`, 
`game_map_id`, `game_version`, `region`, `filename`, `size`, `updated_at`, `created_at`)
 values (7c8acf54-e0d1-7642-d1e3-219c21251628, UnrankedDraft, 2019-10-28 21:59:10,
 1138, , 2.48.2.76893, 2, 7c8acf54-e0d1-7642-d1e3-219c21251628, 1311216, 
2019-12-26 13:38:51, 2019-12-26 13:38:51))
```

Adding a default value for the `deleted` column on the `replays` table solves the issue.