### PR TITLE
add some missing database setup

### DIFF
--- a/database/migrations/2019_12_26_134611_add_default_value_for_deleted.php
+++ b/database/migrations/2019_12_26_134611_add_default_value_for_deleted.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddDefaultValueForDeleted extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // https://stackoverflow.com/a/42107554/9539
+        DB::getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
+        Schema::table('replays', function (Blueprint $table) {
+            $table->integer('deleted')->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // https://stackoverflow.com/a/42107554/9539
+        DB::getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
+        Schema::table('replays', function (Blueprint $table) {
+            $table->integer('deleted')->default(NULL)->change();
+        });
+    }
+}

--- a/database/migrations/2019_12_27_145604_add_storm_league_enum.php
+++ b/database/migrations/2019_12_27_145604_add_storm_league_enum.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddStormLeagueEnum extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::statement('ALTER TABLE `hotsapi`.`replays` CHANGE COLUMN `game_type` `game_type` ENUM(\'QuickMatch\', \'UnrankedDraft\', \'HeroLeague\', \'TeamLeague\', \'Brawl\', \'StormLeague\') NULL DEFAULT NULL');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::statement('ALTER TABLE `hotsapi`.`replays` CHANGE COLUMN `game_type` `game_type` ENUM(\'QuickMatch\', \'UnrankedDraft\', \'HeroLeague\', \'TeamLeague\', \'Brawl\') NULL DEFAULT NULL');
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 
 class DatabaseSeeder extends Seeder
 {
@@ -11,6 +12,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // $this->call(UsersTableSeeder::class);
+        DB::insert("INSERT IGNORE INTO counters (name, value) SELECT 'parsed_id', IFNULL(MAX(parsed_id), 0) FROM replays");
     }
 }


### PR DESCRIPTION
I've run into a couple of issues related to the database when setting up a developer environment:

* Uploading a replay fails with:

```
SQLSTATE[HY000]: General error: 1364 Field 'deleted' doesn't have a default value 
(SQL: insert into `replays` (`fingerprint`, `game_type`, `game_date`, `game_length`, 
`game_map_id`, `game_version`, `region`, `filename`, `size`, `updated_at`, `created_at`)
 values (7c8acf54-e0d1-7642-d1e3-219c21251628, UnrankedDraft, 2019-10-28 21:59:10,
 1138, , 2.48.2.76893, 2, 7c8acf54-e0d1-7642-d1e3-219c21251628, 1311216, 
2019-12-26 13:38:51, 2019-12-26 13:38:51))
```
* Uploading also fails when there is no enum for `StormLeague` on column `game_type` in the `replays` table.
* Parsing replays fail because there is not a starting value for `parsed_id`.

